### PR TITLE
Add package.yaml to support indexing on haindex.org

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -1,0 +1,17 @@
+name: Emergency alerts from .krisinformation.se
+description: A custom lovelace card to accompany the custom component for emergency information from Swedish authorities
+type: lovelace
+keywords:
+  - krisinformation.de
+  - sweden
+  - swedish
+  - emergency
+  - krisis
+  - crisis
+author:
+  name: Isabella Gross Alström
+  email: isabella.alstrom@gmail.com
+  homepage: https://isabellaalstrom.github.io/
+license: MIT
+files:
+  - krisinfo-card.js

--- a/package.yaml
+++ b/package.yaml
@@ -1,4 +1,4 @@
-name: Emergency alerts from .krisinformation.se
+name: Emergency alerts from krisinformation.se
 description: A custom lovelace card to accompany the custom component for emergency information from Swedish authorities
 type: lovelace
 keywords:


### PR DESCRIPTION
Hey Isabella,

here's my pull request to support indexing of your card on https://haindex.org
Since you didn't provide a license yet, I've been bold and added MIT licensing.

Would be great if you could head over to https://haindex.org, log in with your GitHub account and just paste the link to your repository for indexing: https://github.com/isabellaalstrom/krisinfo-card
The index will then take over and do all the rest.

Thanks, Jens